### PR TITLE
Enhance token auth and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ The application listens on port `5000` by default. Visit `http://localhost:5000/
 
 ### Simulate an Upload
 
-Use the `simulate_upload.sh` script to send a file to the server, simulating an upload from a GitHub Action:
+Use the `simulate_upload.sh` script to send a file to the server, simulating an upload from a GitHub Action. The script requires a `GH_TOKEN` environment variable which will be sent as the `GITHUB_TOKEN` header:
 
 ```bash
+export GH_TOKEN=your-token-value
 ./simulate_upload.sh path/to/your-image.img
 ```
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 from flask import Flask, request, send_from_directory, redirect, url_for, render_template
 import os
 
+# Expected GitHub token for uploads
+EXPECTED_TOKEN = os.environ.get('GH_TOKEN')
+
 app = Flask(__name__)
 UPLOAD_FOLDER = os.path.join(app.root_path, 'uploads')
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
@@ -8,6 +11,9 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 @app.route('/', methods=['GET', 'POST'])
 def index():
     if request.method == 'POST':
+        token = request.headers.get('GITHUB_TOKEN')
+        if not token or token != EXPECTED_TOKEN:
+            return 'Unauthorized', 403
         if 'file' not in request.files:
             return 'No file part', 400
         file = request.files['file']

--- a/simulate_upload.sh
+++ b/simulate_upload.sh
@@ -6,4 +6,9 @@ if [ -z "$FILE" ]; then
   exit 1
 fi
 
-curl -F "file=@${FILE}" http://localhost:5000/
+if [ -z "$GH_TOKEN" ]; then
+  echo "GH_TOKEN environment variable not set"
+  exit 1
+fi
+
+curl -H "GITHUB_TOKEN: ${GH_TOKEN}" -F "file=@${FILE}" http://localhost:5000/

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,20 +3,23 @@
 <head>
     <meta charset="utf-8">
     <title>Image Repository</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-<h1>Uploaded Files</h1>
-<ul>
+<body class="bg-gray-900 text-gray-100 min-h-screen">
+<div class="container mx-auto max-w-xl p-4">
+<h1 class="text-3xl font-bold mb-4 text-center">Uploaded Files</h1>
+<ul class="mb-6 space-y-1">
     {% for file in files %}
     <li><a href="{{ url_for('uploaded_file', filename=file) }}">{{ file }}</a></li>
     {% else %}
     <li>No files uploaded.</li>
     {% endfor %}
 </ul>
-<h2>Upload File</h2>
-<form method="post" enctype="multipart/form-data">
-    <input type="file" name="file">
-    <input type="submit" value="Upload">
+<h2 class="text-2xl font-semibold mb-2">Upload File</h2>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    <input type="file" name="file" class="w-full text-gray-300">
+    <input type="submit" value="Upload" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">
 </form>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add GitHub token verification on upload
- improve upload simulation script with header
- document GH_TOKEN usage
- style HTML with Tailwind dark theme

## Testing
- `python3 -m py_compile app.py`
- `shellcheck simulate_upload.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645e660824832c9dfe8f12d1697bf3