### PR TITLE
Fix header token name

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 @app.route('/', methods=['GET', 'POST'])
 def index():
     if request.method == 'POST':
-        token = request.headers.get('GITHUB_TOKEN')
+        token = request.headers.get('GITHUB-TOKEN')
         if not token or token != EXPECTED_TOKEN:
             return 'Unauthorized', 403
         if 'file' not in request.files:

--- a/simulate_upload.sh
+++ b/simulate_upload.sh
@@ -12,4 +12,4 @@ if [ -z "$GH_TOKEN" ]; then
 fi
 
 echo "GH_TOKEN set as ${GH_TOKEN}"
-curl -H "GITHUB_TOKEN: ${GH_TOKEN}" -F "file=@${FILE}" http://localhost:5000/
+curl -H "GITHUB-TOKEN: ${GH_TOKEN}" -F "file=@${FILE}" http://localhost:5000/


### PR DESCRIPTION
## Summary
- use `GITHUB-TOKEN` header because WSGI strips underscores
- update simulate script accordingly

## Testing
- `bash -n simulate_upload.sh`

------
https://chatgpt.com/codex/tasks/task_e_686460fdfea0832ca24076edb8c30423