### PR TITLE
Add API key tool and JSON upload results

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,25 @@ python app.py
 
 The application listens on port `5000` by default. Visit `http://localhost:5000/` to see the list of uploaded files and use the upload form.
 
-### Simulate an Upload
+### Generate an API key
 
-Use the `simulate_upload.sh` script to send a file to the server, simulating an upload from a GitHub Action. The script requires a `GH_TOKEN` environment variable which will be sent as the `GITHUB_TOKEN` header:
+The server expects an API key for uploads. You can create one using the
+`generate_api_key.sh` script:
 
 ```bash
-export GH_TOKEN=your-token-value
+./generate_api_key.sh
+```
+
+Use the printed key as the value for the `CLOUD_REPOSITORY_APIKEY` environment
+variable.
+
+### Simulate an Upload
+
+Use the `simulate_upload.sh` script to send a file to the server, simulating an upload from a GitHub Action. Set the `CLOUD_REPOSITORY_APIKEY` environment variable to the API key expected by the server:
+
+```bash
+export CLOUD_REPOSITORY_APIKEY="$(./generate_api_key.sh)"
 ./simulate_upload.sh path/to/your-image.img
 ```
 
-The uploaded file will be saved in the `uploads/` directory and listed on the homepage.
+The response from the server will be a JSON object containing the path of the uploaded file and the path to a `sha256` file containing the checksum. Both will be located under the `uploads/` directory and can be used as assets for a GitHub release.

--- a/generate_api_key.sh
+++ b/generate_api_key.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Simple script to generate a random alphabetic API key
+# Outputs the key to STDOUT
+
+# Generate 32 random alphabetic characters
+tr -dc 'A-Za-z' </dev/urandom | head -c 32
+printf "\n"

--- a/simulate_upload.sh
+++ b/simulate_upload.sh
@@ -12,4 +12,5 @@ if [ -z "$CLOUD_REPOSITORY_APIKEY" ]; then
 fi
 
 echo "CLOUD_REPOSITORY_APIKEY set as ${CLOUD_REPOSITORY_APIKEY}"
-curl -H "CLOUD-REPOSITORY-APIKEY: ${CLOUD_REPOSITORY_APIKEY}" -F "file=@${FILE}" http://localhost:5000/
+curl -s -H "CLOUD-REPOSITORY-APIKEY: ${CLOUD_REPOSITORY_APIKEY}" -F "file=@${FILE}" http://localhost:5000/
+echo


### PR DESCRIPTION
## Summary
- add `generate_api_key.sh` to create random API keys
- compute SHA-256 checksums during upload and return JSON with paths
- update upload script to print server response
- document API key generation and JSON response in README

## Testing
- `python -m py_compile app.py`
- `shellcheck simulate_upload.sh generate_api_key.sh`
- `apt-get update`
- `apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_686465f114bc832cad7658d89ee78596