### PR TITLE
Add dedicated /upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-The application listens on port `5000` by default. Visit `http://localhost:5000/` to see the list of uploaded files and use the upload form.
+The application listens on port `5000` by default. Visit `http://localhost:5000/` to see the list of uploaded files.
 
 ### Generate an API key
 
@@ -29,7 +29,7 @@ variable.
 
 ### Simulate an Upload
 
-Use the `simulate_upload.sh` script to send a file to the server, simulating an upload from a GitHub Action. Set the `CLOUD_REPOSITORY_APIKEY` environment variable to the API key expected by the server:
+Use the `simulate_upload.sh` script to send a file to the server, simulating an upload from a GitHub Action. Images are uploaded with a `POST` request to the `/upload` endpoint. Set the `CLOUD_REPOSITORY_APIKEY` environment variable to the API key expected by the server:
 
 ```bash
 export CLOUD_REPOSITORY_APIKEY="$(./generate_api_key.sh)"

--- a/app.py
+++ b/app.py
@@ -39,32 +39,8 @@ app.config['PREFERRED_URL_SCHEME'] = 'https'
 app.register_blueprint(github_bp, url_prefix="/login")
 
 
-@app.route('/', methods=['GET', 'POST'])
+@app.route('/', methods=['GET'])
 def index():
-    if request.method == 'POST':
-        token = request.headers.get('CLOUD-REPOSITORY-APIKEY')
-        if not token or token != EXPECTED_TOKEN:
-            return 'Unauthorized', 403
-        if 'file' not in request.files:
-            return 'No file part', 400
-        file = request.files['file']
-        if file.filename == '':
-            return 'No selected file', 400
-        filepath = os.path.join(UPLOAD_FOLDER, file.filename)
-        file.save(filepath)
-
-        # Calculate sha256 and store alongside the uploaded file
-        with open(filepath, 'rb') as f:
-            digest = hashlib.sha256(f.read()).hexdigest()
-        sha_path = filepath + '.sha256'
-        with open(sha_path, 'w') as sf:
-            sf.write(digest)
-
-        return jsonify({
-            'path': url_for('uploaded_file', filename=file.filename, _external=False),
-            'sha256_file': url_for('uploaded_file', filename=file.filename + '.sha256', _external=False),
-            'sha256': digest
-        })
     files = os.listdir(UPLOAD_FOLDER)
     groups = []
     file_set = set(files)
@@ -77,6 +53,33 @@ def index():
             'sha256': sha_name if sha_name in file_set else None
         })
     return render_template('index.html', files=groups, logged_in=github.authorized)
+
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    token = request.headers.get('CLOUD-REPOSITORY-APIKEY')
+    if not token or token != EXPECTED_TOKEN:
+        return 'Unauthorized', 403
+    if 'file' not in request.files:
+        return 'No file part', 400
+    file = request.files['file']
+    if file.filename == '':
+        return 'No selected file', 400
+    filepath = os.path.join(UPLOAD_FOLDER, file.filename)
+    file.save(filepath)
+
+    # Calculate sha256 and store alongside the uploaded file
+    with open(filepath, 'rb') as f:
+        digest = hashlib.sha256(f.read()).hexdigest()
+    sha_path = filepath + '.sha256'
+    with open(sha_path, 'w') as sf:
+        sf.write(digest)
+
+    return jsonify({
+        'path': url_for('uploaded_file', filename=file.filename, _external=False),
+        'sha256_file': url_for('uploaded_file', filename=file.filename + '.sha256', _external=False),
+        'sha256': digest
+    })
 
 
 @app.route('/files/<path:filename>')

--- a/docs/github_action_integration.md
+++ b/docs/github_action_integration.md
@@ -10,7 +10,7 @@ This document describes how to interact with the cloud-image-repository from a G
 ```bash
 curl -H "CLOUD-REPOSITORY-APIKEY: ${{ secrets.CLOUD_REPOSITORY_APIKEY }}" \
      -F "file=@path/to/image.img" \
-     https://your-repo-host.tld/
+     https://your-repo-host.tld/upload
 ```
 
 The server returns JSON similar to:
@@ -33,7 +33,7 @@ The server returns JSON similar to:
   run: |
     response=$(curl -s -H "CLOUD-REPOSITORY-APIKEY: ${{ secrets.CLOUD_REPOSITORY_APIKEY }}" \
                    -F "file=@${{ steps.build.outputs.image }}" \
-                   https://your-repo-host.tld/)
+                   https://your-repo-host.tld/upload)
     echo "response=$response" >> "$GITHUB_OUTPUT"
 ```
 

--- a/simulate_upload.sh
+++ b/simulate_upload.sh
@@ -12,5 +12,5 @@ if [ -z "$CLOUD_REPOSITORY_APIKEY" ]; then
 fi
 
 echo "CLOUD_REPOSITORY_APIKEY set as ${CLOUD_REPOSITORY_APIKEY}"
-curl -s -H "CLOUD-REPOSITORY-APIKEY: ${CLOUD_REPOSITORY_APIKEY}" -F "file=@${FILE}" http://localhost:5000/
+curl -s -H "CLOUD-REPOSITORY-APIKEY: ${CLOUD_REPOSITORY_APIKEY}" -F "file=@${FILE}" http://localhost:5000/upload
 echo


### PR DESCRIPTION
## Summary
- serve uploads via new `/upload` route
- only show file listing on the index route
- update simulate script to use `/upload`
- document new upload endpoint in README and GitHub Action docs

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68647833dd70832cb27143cf36ee5491