### PR TITLE
Switch uploads to public folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ export CLOUD_REPOSITORY_APIKEY="$(./generate_api_key.sh)"
 ./simulate_upload.sh path/to/your-image.img
 ```
 
-The response from the server will be a JSON object containing the path of the uploaded file and the path to a `sha256` file containing the checksum. Both will be located under the `uploads/` directory and can be used as assets for a GitHub release.
+The response from the server will be a JSON object containing the path of the uploaded file and the path to a `sha256` file containing the checksum. Both will be located under the `public/` directory and can be used as assets for a GitHub release.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -7,16 +7,15 @@ from app.routes import main_bp
 
 
 def create_app():
-    app = Flask(__name__,
+    app = Flask(
+        __name__,
         static_folder="../../public",
-        static_url_path="/public"
+        static_url_path="/public",
     )
     app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
     app.secret_key = os.environ.get('FLASK_SECRET_KEY', 'secret')
 
-    upload_folder = os.path.join(app.root_path, 'public')
-    os.makedirs(upload_folder, exist_ok=True)
-    app.config['UPLOAD_FOLDER'] = upload_folder
+    os.makedirs(app.static_folder, exist_ok=True)
     app.config['CLOUD_REPOSITORY_APIKEY'] = os.environ.get('CLOUD_REPOSITORY_APIKEY')
 
     github_bp = make_github_blueprint(

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -24,9 +24,9 @@
         <ul id="fileList" class="mb-6 space-y-1">
             {% for file in files %}
             <li data-name="{{ file.image }}" class="flex items-center">
-                <a class="px-2 py-1 rounded hover:bg-gray-800" href="{{ url_for('uploaded_file', filename=file.image) }}">{{ file.image }}</a>               
+                <a class="px-2 py-1 rounded hover:bg-gray-800" href="{{ url_for('static', filename=file.image) }}">{{ file.image }}</a>
                 {% if file.sha256 %}
-                <a class="px-2 py-1 rounded hover:bg-gray-800" href="{{ url_for('uploaded_file', filename=file.sha256) }}">{{ file.sha256 }}</a>
+                <a class="px-2 py-1 rounded hover:bg-gray-800" href="{{ url_for('static', filename=file.sha256) }}">{{ file.sha256 }}</a>
                 {% endif %}
                 {% if github_conn.authorized %}
                 <form method="post" action="{{ url_for('delete_file', filename=file.image) }}" class="">

--- a/docs/github_action_integration.md
+++ b/docs/github_action_integration.md
@@ -17,8 +17,8 @@ The server returns JSON similar to:
 
 ```json
 {
-  "path": "files/cloud-image-x86-64-jammy-0.1.33.img",
-  "sha256_file": "files/cloud-image-x86-64-jammy-0.1.33.img.sha256",
+  "path": "public/cloud-image-x86-64-jammy-0.1.33.img",
+  "sha256_file": "public/cloud-image-x86-64-jammy-0.1.33.img.sha256",
   "sha256": "..."
 }
 ```


### PR DESCRIPTION
## Summary
- save uploads to the app's `public` static directory
- serve files from `/public` instead of `/files`
- document the new path in README and integration docs

## Testing
- `python3 -m py_compile backend/app/*.py backend/run.py`

------
https://chatgpt.com/codex/tasks/task_e_686495984bf8832c9bdd5435c586ff5a